### PR TITLE
Add Support for Custom Domains

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "LoginRadius",
   "name": "loginradius-react",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "main": "build/index.js",
   "module": "build/index.esm.js",
   "types": "build/index.d.ts",

--- a/src/LRClient.ts
+++ b/src/LRClient.ts
@@ -9,6 +9,7 @@ export interface LRConfigOptions {
   appName: string;
   apiKey: string;
   redirectUri: string;
+  customDomain?: string;
 }
 
 export interface PopupConfigOptions {
@@ -61,13 +62,16 @@ export default class LRClient {
    * @return { Promise<TokenInfo>} Returns weather the use is logged in or not.
    */
   public async getAccessTokenSilently(): Promise<TokenInfo> {
-    return await fetch(
-      `https://${this.options.appName}.hub.loginradius.com/ssologin/login`,
-      {
-        method: "get",
-        credentials: "include",
-      }
-    )
+    let url;
+    if (this.options.customDomain) {
+      url = `https://${this.options.customDomain}/ssologin/login`;
+    } else {
+      url = `https://${this.options.appName}.hub.loginradius.com/ssologin/login`;
+    }
+    return await fetch(url, {
+      method: "get",
+      credentials: "include",
+    })
       .then((res) => res.json())
       .then((data) => data);
   }
@@ -79,7 +83,12 @@ export default class LRClient {
    */
   public buildLoginUrl(returnTo: string = "/") {
     const { appName, redirectUri } = this.options;
-    return `https://${appName}.hub.loginradius.com/auth.aspx?action=login&return_url=${redirectUri}${returnTo}`;
+
+    if (this.options.customDomain) {
+      return `https://${this.options.customDomain}/auth.aspx?action=login&return_url=${redirectUri}${returnTo}`;
+    } else {
+      return `https://${appName}.hub.loginradius.com/auth.aspx?action=login&return_url=${redirectUri}${returnTo}`;
+    }
   }
 
   /**
@@ -158,7 +167,11 @@ export default class LRClient {
    */
   public buildLogoutUrl(returnTo: string = "/"): string {
     const { appName, redirectUri } = this.options;
-    return `https://${appName}.hub.loginradius.com/auth.aspx?action=logout&return_url=${redirectUri}${returnTo}`;
+    if (this.options.customDomain) {
+      return `https://${this.options.customDomain}/auth.aspx?action=logout&return_url=${redirectUri}${returnTo}`;
+    } else {
+      return `https://${appName}.hub.loginradius.com/auth.aspx?action=logout&return_url=${redirectUri}${returnTo}`;
+    }
   }
 
   /**

--- a/src/components/lr-auth-provider.tsx
+++ b/src/components/lr-auth-provider.tsx
@@ -14,6 +14,7 @@ export interface LRAuthProps {
   appName: string;
   apiKey: string;
   redirectUri: string;
+  customDomain?: string;
   onRedirectCallback?: (tokenInfo?: TokenInfo) => void;
 }
 


### PR DESCRIPTION
#### Checklist

- [X] You created a branch from `develop` branch.
- [X] You PR is raised on `develop` branch and not on`main`.
- [X] You have read the [Contribution Guidlines](CONTRIBUTING.md) before creating this PR.

### Description of the Change

Add support in the library for the optional "customDomain" value to be passed in to allow users to specify that the library should use a customer vanity domain for IDX logins rather than the <appname>.hub.loginradius.com variant.

This is required for third party cookies to work with customer domains.

### Alternate Designs

N/A

### Risk Impact

Risk should be very low as the new parameter is optional so all existing use cases can ignore it.

### Verification Process

We built a version of the library with these changes included. First verifying that omission of the new parameter results in identical behavior as before (sending users to <appname>.hub.loginradius.com).

We also verified that including the new customDomain parameter resulted in users being sent to our custom IDX domain for sign in.

### Release Notes

- Add support for customDomain to be specified in library
